### PR TITLE
Fix exclude dirs being null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,9 +118,12 @@ _TeamCity*
 *.coveragexml
 
 # NCrunch
+*.ncrunch*.user
 _NCrunch_*
-.*crunch*.local.xml
+*.crunch.xml
 nCrunchTemp_*
+.ncrunchsolution
+**/*.ncrunchsolution
 
 # MightyMoose
 *.mm.*

--- a/src/Rhyous.NuGetPackageUpdater.v3.ncrunchsolution
+++ b/src/Rhyous.NuGetPackageUpdater.v3.ncrunchsolution
@@ -1,0 +1,8 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <EnableRDI>False</EnableRDI>
+    <RdiConfigured>True</RdiConfigured>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/Rhyous.NuGetPackageUpdater.v3.ncrunchsolution
+++ b/src/Rhyous.NuGetPackageUpdater.v3.ncrunchsolution
@@ -1,8 +1,0 @@
-﻿<SolutionConfiguration>
-  <Settings>
-    <AllowParallelTestExecution>True</AllowParallelTestExecution>
-    <EnableRDI>False</EnableRDI>
-    <RdiConfigured>True</RdiConfigured>
-    <SolutionConfigured>True</SolutionConfigured>
-  </Settings>
-</SolutionConfiguration>

--- a/src/Rhyous.NuGetPackageUpdater/File/FileFinder.cs
+++ b/src/Rhyous.NuGetPackageUpdater/File/FileFinder.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using Rhyous.NuGetPackageUpdater.Wrappers;
+using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -9,29 +9,47 @@ namespace Rhyous.NuGetPackageUpdater
     internal class FileFinder : IFileFinder
     {
         private readonly ISettings _Settings;
+        private readonly IDirectoryWrapper _DirectoryWrapper;
 
-        public FileFinder(ISettings settings)
+        public FileFinder(ISettings settings, IDirectoryWrapper directoryWrapper)
         {
             _Settings = settings;
+            _DirectoryWrapper = directoryWrapper;
         }
 
         public IList<string> Find(string directory, string pattern)
         {
-            if (_Settings.ExcludeDirs.Contains(directory))
+            if (_Settings.ExcludeDirs != null && _Settings.ExcludeDirs.Contains(directory))
                 return new List<string>();
+
             var fileList = new List<string>();
             var dirList = new List<string>();
+
             try
             {
-                fileList.AddRange(Directory.GetFiles(directory).Where(f => Regex.IsMatch(f, pattern, RegexOptions.IgnoreCase)));
+                var files = _DirectoryWrapper.GetFiles(directory);
+                fileList.AddRange(files.Where(f => Regex.IsMatch(f, pattern, RegexOptions.IgnoreCase)));
             }
-            catch (Exception) { throw; }
-            try { dirList.AddRange(Directory.GetDirectories(directory)); }
-            catch (Exception) { throw; }
+            catch (Exception) 
+            {
+                throw;
+            }
+
+            try 
+            { 
+                var dirs = _DirectoryWrapper.GetDirectories(directory);
+                dirList.AddRange(dirs); 
+            }
+            catch (Exception) 
+            { 
+                throw; 
+            }
+
             foreach (var dir in dirList)
             {
                 fileList.AddRange(Find(dir, pattern));
             }
+
             return fileList;
         }
     }

--- a/src/Rhyous.NuGetPackageUpdater/Program.cs
+++ b/src/Rhyous.NuGetPackageUpdater/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Rhyous.NuGetPackageUpdater.Replacers;
 using Rhyous.NuGetPackageUpdater.TFS;
+using Rhyous.NuGetPackageUpdater.Wrappers;
 using Rhyous.SimpleArgs;
 using System.Threading.Tasks;
 
@@ -15,8 +16,9 @@ namespace Rhyous.NuGetPackageUpdater
             var argsManager = new ArgsManager<ArgsHandler>();
             IArgsReader argsReader = new ArgsReader();
             ISettings settings = new Settings();
+            IDirectoryWrapper directoryWrapper = new DirectoryWrapper();
             IStringReplacer stringReplacer = new StringReplacer();
-            IFileFinder fileFinder = new FileFinder(settings);
+            IFileFinder fileFinder = new FileFinder(settings, directoryWrapper);
             IFileIO fileIO = new FileIO();
             var tfsCheckout = new TFSCheckout(settings);
             INuGetReplacer nuGetReplacer = new NuGetReplacer(stringReplacer, fileFinder, fileIO, settings, tfsCheckout);

--- a/src/Rhyous.NuGetPackageUpdater/Wrappers/DirectoryWrapper.cs
+++ b/src/Rhyous.NuGetPackageUpdater/Wrappers/DirectoryWrapper.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace Rhyous.NuGetPackageUpdater.Wrappers
+{
+    /// <summary>
+    /// An implementation of <see cref="IDirectoryWrapper"/>, wrapping the static <see cref="Directory"/>.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class DirectoryWrapper : IDirectoryWrapper
+    {
+        /// <inheritdoc cref="Directory.GetFiles(string)"/>
+        public string[] GetFiles(string path)
+        {
+            return Directory.GetFiles(path);
+        }
+
+        /// <inheritdoc cref="Directory.GetDirectories(string)"
+        public string[] GetDirectories(string path) 
+        { 
+            return Directory.GetDirectories(path); 
+        }
+    }
+}

--- a/src/Rhyous.NuGetPackageUpdater/Wrappers/IDirectoryWrapper.cs
+++ b/src/Rhyous.NuGetPackageUpdater/Wrappers/IDirectoryWrapper.cs
@@ -1,0 +1,11 @@
+﻿namespace Rhyous.NuGetPackageUpdater.Wrappers
+{
+    /// <summary>
+    /// Interface for wrapping <see cref="System.IO.Directory"/>
+    /// </summary>
+    public interface IDirectoryWrapper
+    {
+        string[] GetFiles(string path);
+        string[] GetDirectories(string path);
+    }
+}

--- a/src/Rhyous.NugetPacakgeUpdater.Tests/File/FileFinderTests.cs
+++ b/src/Rhyous.NugetPacakgeUpdater.Tests/File/FileFinderTests.cs
@@ -1,0 +1,353 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Rhyous.NuGetPackageUpdater;
+using Rhyous.NuGetPackageUpdater.Wrappers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rhyous.NugetPacakgeUpdater.Tests.File
+{
+    [TestClass]
+    public class FileFinderTests
+    {
+        private MockRepository mockRepository;
+        private Mock<ISettings> mockSettings;
+        private Mock<IDirectoryWrapper> mockDirectoryWrapper;
+
+        /// <summary>
+        /// Helper function to get total count of items in a test dictionary.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        private int GetFileCount(Dictionary<string, string[]> input)
+        {
+            int totalFiles = 0;
+
+            foreach (var kvp in input)
+            {
+                totalFiles += kvp.Value.Length;
+            }
+
+            return totalFiles;
+        }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            mockRepository = new MockRepository(MockBehavior.Strict);
+
+            mockSettings = mockRepository.Create<ISettings>();
+            mockDirectoryWrapper = mockRepository.Create<IDirectoryWrapper>();
+        }
+
+        private FileFinder CreateFileFinder()
+        {
+            return new FileFinder(
+                mockSettings.Object, mockDirectoryWrapper.Object);
+        }
+
+        [TestMethod]
+        public void GetTotalFiles_FiveFilesInTwoKeyValuePairs_GetsFiveFiles()
+        {
+            //Arrange
+            var testInput = new Dictionary<string, string[]>
+            {
+                {"first", new string[] {"one", "two", "three"} },
+                {"second", new string[] {"four", "five"} }
+            };
+
+            //Act
+            var actual = GetFileCount(testInput);
+
+            //Assert
+            Assert.AreEqual(5, actual);
+        }
+        
+        [TestMethod]
+        public void Find_ExcludeDirsIsNull_NoException()
+        {
+            // Arrange
+            mockSettings.Setup(x => x.ExcludeDirs).Returns(new Func<List<string>>(() => null));
+            mockDirectoryWrapper.Setup(x => x.GetFiles(It.IsAny<string>())).Returns(Array.Empty<string>());
+            mockDirectoryWrapper.Setup(x => x.GetDirectories(It.IsAny<string>())).Returns(Array.Empty<string>());
+
+            var fileFinder = CreateFileFinder();
+            string directory = @"C:\";
+            string pattern = "";
+
+            // Act
+            var result = fileFinder.Find(directory, pattern);
+
+            // Assert
+            Assert.IsNotNull(result, "Don't throw an exception if Settings.ExcludeDirs is null.");
+            mockRepository.VerifyAll();
+        }
+
+        [TestMethod]
+        public void Find_NoFilesOrDiretoriesFound_ReturnsEmptyList()
+        {
+            // Arrange
+            mockSettings.Setup(x => x.ExcludeDirs).Returns(new List<string>());
+            mockDirectoryWrapper.Setup(x => x.GetFiles(It.IsAny<string>())).Returns(Array.Empty<string>());
+            mockDirectoryWrapper.Setup(x => x.GetDirectories(It.IsAny<string>())).Returns(Array.Empty<string>());
+
+            var fileFinder = CreateFileFinder();
+            string directory = @"C:\";
+            string pattern = "";
+
+            // Act
+            var result = fileFinder.Find(directory, pattern);
+
+            // Assert
+            Assert.AreEqual(0, result.Count, "Don't add false finds.");
+            mockRepository.VerifyAll();
+        }
+
+        [TestMethod]
+        public void Find_ExcludeDirsContainsGivenPath_ReturnEmptyList()
+        {
+            //Arrange
+            mockSettings.Setup(x => x.ExcludeDirs).Returns(new List<string> {@"C:\"});
+            var subject = CreateFileFinder();
+            string directory = @"C:\";
+            string pattern = "";
+
+            //Act
+            var actual = subject.Find(directory, pattern);
+
+            //Assert
+            Assert.AreEqual(0, actual.Count, "Return an empty list if ExcludeDirs contains the current path.");
+            mockRepository.VerifyAll();
+        }
+
+        [TestMethod]
+        public void Find_OneLevelThreeFiles_ReturnsThreeFiles()
+        {
+            //Arrange
+            mockSettings.Setup(x => x.ExcludeDirs).Returns(new List<string>());
+            var testFileList = new string[] {@"C:\one.txt", @"C:\two.txt", @"C:\three.txt"};
+
+            mockDirectoryWrapper.Setup(x => x.GetDirectories(It.IsAny<string>())).Returns(Array.Empty<string>);
+            mockDirectoryWrapper.Setup(x => x.GetFiles(It.IsAny<string>())).Returns(testFileList);
+
+            var subject = CreateFileFinder();
+            string directory = @"C:\";
+            string pattern = "";
+
+            //Act
+            var actual = subject.Find(directory, pattern);
+
+            //Assert
+            Assert.AreEqual(testFileList.Length, actual.Count);
+            mockRepository.VerifyAll();
+        }
+        
+        [TestMethod]
+        public void Find_TwoLevelsFourFilesTotal_ReturnsFourFiles()
+        {
+            //Arrange
+            mockSettings.Setup(x => x.ExcludeDirs).Returns(new List<string>());
+
+            var mockFileStructure = new Dictionary<string, string[]> 
+            {
+                { @"C:\", new string[] { @"C:\one.txt", @"C:\two.txt" } },
+                { @"C:\folder", new string[] { @"C:\folder\three.txt", @"C:\folder\four.txt" }}
+            };
+            var expectedFileCount = GetFileCount(mockFileStructure);
+            
+            var mockFolderStructure = new Dictionary<string, string[]>
+            {
+                { @"C:\", new string[] {@"C:\folder"} },
+                { @"C:\folder" , Array.Empty<string>() }
+            };
+
+            mockDirectoryWrapper.Setup(x => x.GetDirectories(It.IsAny<string>())).Returns(new Func<string, string[]>(path => mockFolderStructure[path]));
+            mockDirectoryWrapper.Setup(x => x.GetFiles(It.IsAny<string>())).Returns(new Func<string, string[]>(path => mockFileStructure[path]));
+
+            var subject = CreateFileFinder();
+            string directory = @"C:\";
+            string pattern = "";
+
+            //Act
+            var actual = subject.Find(directory, pattern);
+
+            //Assert
+            Assert.AreEqual(expectedFileCount, actual.Count);
+            mockRepository.VerifyAll();
+        }
+
+        [TestMethod]
+        public void Find_ComplexStructure_GetsCorrectCountOfFiles()
+        {
+            //Arrange
+            mockSettings.Setup(x => x.ExcludeDirs).Returns(new List<string>());
+
+            var defaultDirectories = new Dictionary<string, string[]> 
+            {
+                { @"C:\",  new string[] {@"C:\bothInside", @"C:\onlyNested", @"C:\onlyFiles", @"C:\empty"} },
+                { @"C:\bothInside", new string[] {@"C:\bothInside\firstNested"} },
+                { @"C:\bothInside\firstNested", Array.Empty<string>() },
+                { @"C:\onlyNested", new string[]{ @"C:\onlyNested\secondNested" } },
+                { @"C:\onlyNested\secondNested", Array.Empty<string>() },
+                { @"C:\onlyFiles", Array.Empty<string>() },
+                { @"C:\empty", Array.Empty<string>() }
+            };
+
+            var defaultFiles = new Dictionary<string, string[]>()
+            {
+                { @"C:\",  Array.Empty<string>() },
+                { @"C:\bothInside", new string[] {@"C:\bothInside\testing.txt"} },
+                { @"C:\bothInside\firstNested", Array.Empty<string>() },
+                { @"C:\onlyNested", Array.Empty<string>() },
+                { @"C:\onlyNested\secondNested", Array.Empty<string>() },
+                { @"C:\onlyFiles", new string[] { @"C:\onlyFiles\firstFile.txt", @"C:\onlyFiles\secondFile.txt" } },
+                { @"C:\empty", Array.Empty<string>() }
+            };
+
+            var expectedFileCount = GetFileCount(defaultFiles);
+            
+            mockDirectoryWrapper.Setup(x => x.GetFiles(It.IsAny<string>())).Returns(new Func<string, string[]>(path => defaultFiles[path]));
+            mockDirectoryWrapper.Setup(x => x.GetDirectories(It.IsAny<string>())).Returns(new Func<string, string[]>(path => defaultDirectories[path]));
+
+            var subject = CreateFileFinder();
+
+            //Act
+            var actual = subject.Find(@"C:\", "");
+
+            //Assert
+            Assert.AreEqual(expectedFileCount, actual.Count);
+        }
+
+        [TestMethod]
+        public void Find_ExcludeDirsHasExclusions_FindNonExcludedFiles()
+        {
+            //Arrange
+            var dirs = new Dictionary<string, string[]>
+            {
+                { @"C:\", new string[] {@"C:\include", @"C:\exclude"} },
+                { @"C:\include", new string[] {@"C:\include\exclude" } },
+                { @"C:\include\exclude", Array.Empty<string>() },
+                { @"C:\exclude", Array.Empty<string>() }
+            };
+
+            var files = new Dictionary<string, string[]>
+            {
+                { @"C:\", new string[] { @"C:\one.txt" } },
+                { @"C:\include", new string[] { @"C:\include\two.txt" } },
+                { @"C:\include\exclude", new string[] { @"C:\include\exclude\three.txt" } },
+                { @"C:\exclude", new string[] { @"C:\exclude\four.txt" } }
+            };
+
+            var dirsToExclude = new List<string> {@"C:\exclude", @"C:\include\exclude"};
+
+            mockDirectoryWrapper.Setup(x => x.GetFiles(It.IsAny<string>())).Returns(new Func<string, string[]>(path => files[path]));
+            mockDirectoryWrapper.Setup(x => x.GetDirectories(It.IsAny<string>())).Returns(new Func<string, string[]>(path => dirs[path]));
+
+            mockSettings.Setup(x => x.ExcludeDirs).Returns(dirsToExclude);
+
+            var subject = CreateFileFinder();
+
+            //Act
+            var actual = subject.Find(@"C:\", "");
+
+            //Assert
+            Assert.AreEqual(2, actual.Count);
+        }
+
+        [TestMethod]
+        public void Find_WithPattern_FindsCorrectFiles()
+        {
+            //Arrange
+            var dirs = new Dictionary<string, string[]>
+            {
+                { @"C:\", Array.Empty<string>() }
+            };
+
+            var files = new Dictionary<string, string[]>
+            {
+                { @"C:\", new string[] { @"C:\correct.txt", @"C:\incorrect.xml" } }
+            };
+
+            mockDirectoryWrapper.Setup(x => x.GetFiles(It.IsAny<string>())).Returns(new Func<string, string[]>(path => files[path]));
+            mockDirectoryWrapper.Setup(x => x.GetDirectories(It.IsAny<string>())).Returns(new Func<string, string[]>(path => dirs[path]));
+
+            mockSettings.Setup(x => x.ExcludeDirs).Returns(new List<string>());
+
+            var subject = CreateFileFinder();
+
+            //Act
+            var actual = subject.Find(@"C:\", ".txt");
+
+            //Assert
+            Assert.AreEqual(1, actual.Count);
+            Assert.IsFalse(actual.Any(x => x.Contains(".xml")));
+        }
+
+        [TestMethod]
+        public void Find_UnixFilePaths_FindsFiles()
+        {
+            //Arrange
+            var dirs = new Dictionary<string, string[]>
+            {
+                { "/etc", Array.Empty<string>() }
+            };
+
+            var files = new Dictionary<string, string[]>
+            {
+                { "/etc", new string[] { "etc/correct.txt", "etc/incorrect.xml" } }
+            };
+
+            mockDirectoryWrapper.Setup(x => x.GetFiles(It.IsAny<string>())).Returns(new Func<string, string[]>(path => files[path]));
+            mockDirectoryWrapper.Setup(x => x.GetDirectories(It.IsAny<string>())).Returns(new Func<string, string[]>(path => dirs[path]));
+
+            mockSettings.Setup(x => x.ExcludeDirs).Returns(new List<string>());
+
+            var subject = CreateFileFinder();
+
+            //Act
+            var actual = subject.Find("/etc", ".txt");
+
+            //Assert
+            Assert.AreEqual(1, actual.Count);
+            Assert.IsFalse(actual.Any(x => x.Contains(".xml")));
+        }
+
+        
+        [TestMethod]
+        public void Find_PatternsAndExclusions_FindNonExcludedFiles()
+        {
+            //Arrange
+            var dirs = new Dictionary<string, string[]>
+            {
+                { @"C:\", new string[] {@"C:\include", @"C:\exclude"} },
+                { @"C:\include", new string[] {@"C:\include\exclude" } },
+                { @"C:\include\exclude", Array.Empty<string>() },
+                { @"C:\exclude", Array.Empty<string>() }
+            };
+
+            var files = new Dictionary<string, string[]>
+            {
+                { @"C:\", new string[] { @"C:\one.xml" } },
+                { @"C:\include", new string[] { @"C:\include\two.txt", @"C:\include\failsPattern.xml" } },
+                { @"C:\include\exclude", new string[] { @"C:\include\exclude\three.txt", @"C:\include\exclude\shouldNotGetFound.txt" } },
+                { @"C:\exclude", new string[] { @"C:\exclude\four.txt" } }
+            };
+
+            var dirsToExclude = new List<string> {@"C:\exclude", @"C:\include\exclude"};
+
+            mockDirectoryWrapper.Setup(x => x.GetFiles(It.IsAny<string>())).Returns(new Func<string, string[]>(path => files[path]));
+            mockDirectoryWrapper.Setup(x => x.GetDirectories(It.IsAny<string>())).Returns(new Func<string, string[]>(path => dirs[path]));
+
+            mockSettings.Setup(x => x.ExcludeDirs).Returns(dirsToExclude);
+
+            var subject = CreateFileFinder();
+
+            //Act
+            var actual = subject.Find(@"C:\", ".txt");
+
+            //Assert
+            Assert.AreEqual(1, actual.Count);
+        }
+    }
+}


### PR DESCRIPTION
Added a fix for ISettings.ExcludeDirs being null if the command line parameter wasn't given, and added unit tests.